### PR TITLE
Fixes for julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
-language: cpp
-compiler:
-  - clang
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
+language: julia
+os:
+  - linux
+  - osx
+julia:
+  - 1.0
+  - 1.1
+  - 1.2
+  - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
 notifications:
   email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-  - julia --check-bounds=yes -e 'versioninfo(); Pkg.init(); Pkg.clone("https://github.com/saltpork/Stage.jl"); Pkg.clone(pwd()); Pkg.build("LispSyntax"); Pkg.test("LispSyntax")'

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,15 @@
+name = "LispSyntax"
+uuid = "51c06dcf-91d3-5c9e-a52e-02df4e7cbcf5"
+
+[deps]
+ParserCombinator = "fae87a5f-d1ad-5cf0-8f61-c941e1580b46"
+
+[compat]
+ParserCombinator = "≥ 2.0.0"
+julia = "≥ 1.0.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "LispSyntax"
 uuid = "51c06dcf-91d3-5c9e-a52e-02df4e7cbcf5"
+version = "0.2.0"
 
 [deps]
 ParserCombinator = "fae87a5f-d1ad-5cf0-8f61-c941e1580b46"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.4 0.5
-ParserCombinator 1.7.4
-

--- a/src/LispSyntax.jl
+++ b/src/LispSyntax.jl
@@ -16,9 +16,9 @@ function desx(s)
   if typeof(s) == s_expr
     return map(desx, s.vector)
   elseif isa(s, Dict)
-    return Dict(map(x -> desx(x[1]) => desx(x[2]), s)...)
+    return Dict(desx(x[1])=>desx(x[2]) for x in s)
   elseif isa(s, Set)
-    return Set(map(desx, s))
+    return Set(desx(v) for v in s)
   else
     return s
   end
@@ -39,13 +39,13 @@ function assign_reader_dispatch(sym, fn)
   reader_table[sym] = fn
 end
 
-function quasiquote(s, escape_exceptions)
+function quasiquote(s)
   if isa(s, Array) && length(s) == 2 && s[1] == :splice
-    codegen(s[2], escape_exceptions = escape_exceptions)
+    codegen(s[2])
   elseif isa(s, Array) && length(s) == 2 && s[1] == :splice_seq
-    Expr(:..., codegen(s[2], escape_exceptions = escape_exceptions))
+    Expr(:..., codegen(s[2]))
   elseif isa(s, Array)
-    Expr(:call, :construct_sexpr, map(s -> quasiquote(s, escape_exceptions), s)...)
+    Expr(:call, construct_sexpr, map(quasiquote, s)...)
   elseif isa(s, Symbol)
     Expr(:quote, s)
   else
@@ -55,7 +55,7 @@ end
 
 function quote_it(s)
   if isa(s, Array)
-    Expr(:call, :construct_sexpr, map(s -> quote_it(s), s)...)
+    Expr(:call, construct_sexpr, map(s -> quote_it(s), s)...)
   elseif isa(s, Symbol)
    QuoteNode(s)
   else
@@ -63,83 +63,74 @@ function quote_it(s)
   end
 end
 
-function codegen(s; escape_exceptions = Set{Symbol}())
+function codegen(s)
   if isa(s, Symbol)
-    if s in escape_exceptions
       s
-    else
-      esc(s)
-    end
   elseif isa(s, Dict)
-    coded_s = map(x -> Expr(Symbol("=>"),
-                            codegen(x[1], escape_exceptions = escape_exceptions),
-                            codegen(x[2], escape_exceptions = escape_exceptions)), s)
-    Expr(:call, :Dict, coded_s...)
+    coded_s = [:($(codegen(x[1])) => $(codegen(x[2]))) for x in s]
+    Expr(:call, Dict, coded_s...)
   elseif isa(s, Set)
-    coded_s = map(x -> codegen(x, escape_exceptions = escape_exceptions), s)
-    Expr(:call, :Set, Expr(:vect, coded_s...))
+    coded_s = [codegen(x) for x in s]
+    Expr(:call, Set, Expr(:vect, coded_s...))
   elseif !isa(s, Array) # constant
     s
   elseif length(s) == 0 # empty array
     s
   elseif s[1] == :if
     if length(s) == 3
-      :($(codegen(s[2], escape_exceptions = escape_exceptions)) && $(codegen(s[3], escape_exceptions = escape_exceptions)))
+      :($(codegen(s[2])) && $(codegen(s[3])))
     elseif length(s) == 4
-      :($(codegen(s[2], escape_exceptions = escape_exceptions)) ? $(codegen(s[3], escape_exceptions = escape_exceptions)) : $(codegen(s[4],  escape_exceptions = escape_exceptions)))
+      :($(codegen(s[2])) ? $(codegen(s[3])) : $(codegen(s[4])))
     else
       throw("illegal if statement $s")
     end
   elseif s[1] == :def
     length(s) == 3 || error("Malformed def: Length of list must be == 3")
-    :($(esc(s[2])) = $(codegen(s[3], escape_exceptions = escape_exceptions)))
+    :($(s[2]) = $(codegen(s[3])))
   elseif s[1] == :let
-    syms     = Set([ s[2][i] for i = 1:2:length(s[2]) ])
-    bindings = [ :($(s[2][i]) = $(codegen(s[2][i+1], escape_exceptions = escape_exceptions ∪ syms))) for i = 1:2:length(s[2]) ]
-    coded_s  = map(x -> codegen(x, escape_exceptions = escape_exceptions ∪ syms), s[3:end])
-    Expr(:let, Expr(:block, coded_s...), bindings...)
+    bindings = [ :($(s[2][i]) = $(codegen(s[2][i+1]))) for i = 1:2:length(s[2]) ]
+    coded_s  = map(codegen, s[3:end])
+    Expr(:let, Expr(:block, bindings...), Expr(:block, coded_s...))
   elseif s[1] == :while
-    coded_s = map(x -> codegen(x, escape_exceptions = escape_exceptions), s[2:end])
+    coded_s = map(codegen, s[2:end])
     Expr(:while, coded_s[1], Expr(:block, coded_s[2:end]...))
   elseif s[1] == :for
-    syms     = Set([ s[2][i] for i = 1:2:length(s[2]) ])
-    bindings = [ :($(s[2][i]) = $(codegen(s[2][i+1], escape_exceptions = escape_exceptions ∪ syms))) for i = 1:2:length(s[2]) ]
-    coded_s  = map(x -> codegen(x, escape_exceptions = escape_exceptions ∪ syms), s[3:end])
+    bindings = [ :($(s[2][i]) = $(codegen(s[2][i+1]))) for i = 1:2:length(s[2]) ]
+    coded_s  = map(codegen, s[3:end])
     Expr(:for, Expr(:block, bindings...), Expr(:block, coded_s...))
   elseif s[1] == :do
-    Expr(:block, map(x -> codegen(x, escape_exceptions = escape_exceptions), s[2:end])...)
+    Expr(:block, map(codegen, s[2:end])...)
   elseif s[1] == :global
-    Expr(:global, map(x -> esc(x), s[2:end])...)
+    Expr(:global, s[2:end]...)
   elseif s[1] == :quote
     quote_it(s[2])
   elseif s[1] == :import
-     Expr(:using, map(x -> esc(x), s[2:end])...)
+    Expr(:using, [Expr(:., x) for x in s[2:end]]...)
   elseif s[1] == :splice
     throw("missplaced ~ (splice)")
   elseif s[1] == :splice_seq
     throw("missplaced ~@ (splice_seq)")
   elseif s[1] == :quasi
-    quasiquote(s[2], escape_exceptions)
+    quasiquote(s[2])
   elseif s[1] == :lambda || s[1] == :fn
     length(s) >= 3 || error("Malformed lambda/fn: list length must be >= 3")
-    coded_s = map(x -> codegen(x, escape_exceptions = escape_exceptions ∪ Set(s[2])), s[3:end])
+    coded_s = map(codegen, s[3:end])
     Expr(:function, Expr(:tuple, s[2]...), Expr(:block, coded_s...))
   elseif s[1] == :defn
     # Note: julia's lambdas are not optimized yet, so we don't define defn as a macro.
     #       this should be revisited later.
-    coded_s = map(x -> codegen(x, escape_exceptions = escape_exceptions ∪ Set(s[3])), s[4:end])
-    Expr(:function, Expr(:call, esc(s[2]), s[3]...), Expr(:block, coded_s...))
+    coded_s = map(codegen, s[4:end])
+    Expr(:function, Expr(:call, s[2], s[3]...), Expr(:block, coded_s...))
   elseif s[1] == :defmacro
-     Expr(:macro, Expr(:call, esc(s[2]), s[3]...),
+     Expr(:macro, Expr(:call, s[2], s[3]...),
           begin
-            coded_s = map(x -> codegen(x, escape_exceptions = escape_exceptions ∪ Set(s[3])), s[4:end])
-            sexpr = Expr(:block, coded_s...) #codegen(s[4], escape_exceptions = escape_exceptions ∪ Set(s[3]))
-            :(codegen($sexpr, escape_exceptions = $escape_exceptions ∪ Set($(s[3]))))
+            sexpr = Expr(:block, map(codegen, s[4:end])...)
+            Expr(:block, Expr(:call, codegen, sexpr))
           end)
   elseif s[1] == :defmethod
     # TODO
   else
-    coded_s = map(x -> codegen(x, escape_exceptions = escape_exceptions), s)
+    coded_s = map(codegen, s)
     if (typeof(coded_s[1]) == Symbol && occursin(r"^@.*$", string(coded_s[1]))) ||
        (typeof(coded_s[1]) == Expr && occursin(r"^@.*$", string(coded_s[1].args[1])))
       Expr(:macrocall, coded_s[1], nothing, coded_s[2:end]...)
@@ -156,11 +147,11 @@ function lisp_eval_helper(str :: AbstractString)
 end
     
 macro lisp(str)
-  return lisp_eval_helper(str)
+  return esc(lisp_eval_helper(str))
 end
 
 macro lisp_str(str)
-  return lisp_eval_helper(str)
+  return esc(lisp_eval_helper(str))
 end
 
 end # module

--- a/src/pegparser.jl
+++ b/src/pegparser.jl
@@ -1,3 +1,5 @@
+# PEGParser is a dead package. See parser.jl instead.
+
 using PEGParser
 
 @grammar lisp_grammar begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using LispSyntax
-using Stage
+using Test
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Setup
@@ -14,75 +14,75 @@ end
 # ----------------------------------------------------------------------------------------------------------------------
 # Reader
 # ----------------------------------------------------------------------------------------------------------------------
-@expect LispSyntax.read("1.1f") == 1.1f0
-@expect LispSyntax.read("1.2f") == 1.2f0
-@expect LispSyntax.read("2f")   == 2f0
+@test LispSyntax.read("1.1f") == 1.1f0
+@test LispSyntax.read("1.2f") == 1.2f0
+@test LispSyntax.read("2f")   == 2f0
 
-@expect LispSyntax.read("3.0d") == 3.0
+@test LispSyntax.read("3.0d") == 3.0
 
-@expect LispSyntax.read("4")    == 4
+@test LispSyntax.read("4")    == 4
 
-@expect LispSyntax.read("\\u2312") == '\u2312'
+@test LispSyntax.read("\\u2312") == '\u2312'
 
-@expect LispSyntax.read("\\040") == ' '
+@test LispSyntax.read("\\040") == ' '
 
-@expect LispSyntax.read("\\c") == 'c'
+@test LispSyntax.read("\\c") == 'c'
 
-@expect LispSyntax.read("\"test\"") == "test"
+@test LispSyntax.read("\"test\"") == "test"
 
-@expect LispSyntax.read("true") == true
-@expect LispSyntax.read("false") == false
+@test LispSyntax.read("true") == true
+@test LispSyntax.read("false") == false
 
-@expect LispSyntax.read("test") == :test
+@test LispSyntax.read("test") == :test
 
-@expect LispSyntax.read("()") == sx()
-@expect LispSyntax.read("(1.1f)") == sx(1.1f0)
-@expect LispSyntax.read("(1.1f 2.2f)") == sx(1.1f0, 2.2f0)
-@expect LispSyntax.read("(+ 1.1f 2)") == sx(:+, 1.1f0, 2)
-@expect LispSyntax.read("(this (+ 1.1f 2))") == sx(:this, sx(:+, 1.1f0, 2))
-@expect LispSyntax.read("(this (+ 1.1f 2) )") == sx(:this, sx(:+, 1.1f0, 2))
+@test LispSyntax.read("()") == sx()
+@test LispSyntax.read("(1.1f)") == sx(1.1f0)
+@test LispSyntax.read("(1.1f 2.2f)") == sx(1.1f0, 2.2f0)
+@test LispSyntax.read("(+ 1.1f 2)") == sx(:+, 1.1f0, 2)
+@test LispSyntax.read("(this (+ 1.1f 2))") == sx(:this, sx(:+, 1.1f0, 2))
+@test LispSyntax.read("(this (+ 1.1f 2) )") == sx(:this, sx(:+, 1.1f0, 2))
 
-@expect LispSyntax.read("#{1 2 3 4}") == Set([1, 2, 3, 4])
+@test LispSyntax.read("#{1 2 3 4}") == Set([1, 2, 3, 4])
 
-@expect LispSyntax.read("""#{
+@test LispSyntax.read("""#{
                         1 2 
                         3 4
                         }""") == Set([1, 2, 3, 4])
 
-@expect LispSyntax.read("{a 2 b 3}") == Dict(:a => 2, :b => 3)
+@test LispSyntax.read("{a 2 b 3}") == Dict(:a => 2, :b => 3)
 
-@expect LispSyntax.read("""{
+@test LispSyntax.read("""{
                         a 2 
                         b 3
                         }""") == Dict(:a => 2, :b => 3)
 
-@expect LispSyntax.read("[1 2 3 4]")  == sx(1, 2, 3, 4)
+@test LispSyntax.read("[1 2 3 4]")  == sx(1, 2, 3, 4)
 
-@expect LispSyntax.read("""[
+@test LispSyntax.read("""[
                         1 2 
                         3 4
                         ]""")  == sx(1, 2, 3, 4)
 
-@expect LispSyntax.read("[]")         == sx()
-@expect LispSyntax.read("[1]")        == sx(1)
+@test LispSyntax.read("[]")         == sx()
+@test LispSyntax.read("[1]")        == sx(1)
 
-@expect LispSyntax.read("'test")      == sx(:quote, :test)
+@test LispSyntax.read("'test")      == sx(:quote, :test)
 
-@expect LispSyntax.read("`test")      == sx(:quasi, :test)
+@test LispSyntax.read("`test")      == sx(:quasi, :test)
 
-@expect LispSyntax.read("~test")      == sx(:splice, :test)
-@expect LispSyntax.read("~@(1 2 3)")  == sx(:splice_seq, sx(1, 2, 3))
+@test LispSyntax.read("~test")      == sx(:splice, :test)
+@test LispSyntax.read("~@(1 2 3)")  == sx(:splice_seq, sx(1, 2, 3))
 
-@expect LispSyntax.read("`~test")     == sx(:quasi, sx(:splice, :test))
+@test LispSyntax.read("`~test")     == sx(:quasi, sx(:splice, :test))
 
-@expect desx(sx(:splice_seq, sx(1, 2, 3))) == Any[ :splice_seq, [1, 2, 3] ]
-@expect desx(sx(:splice_seq, sx(1, 2, sx(3)))) == Any[ :splice_seq, Any[ 1, 2, [3] ] ]
+@test desx(sx(:splice_seq, sx(1, 2, 3))) == Any[ :splice_seq, [1, 2, 3] ]
+@test desx(sx(:splice_seq, sx(1, 2, sx(3)))) == Any[ :splice_seq, Any[ 1, 2, [3] ] ]
 
-@expect LispSyntax.read("""(defn multiline
+@test LispSyntax.read("""(defn multiline
                            [x]
                            (+ x 1))""") == sx(:defn, :multiline, sx(:x), sx(:+, :x, 1))
 
-@expect LispSyntax.read("""
+@test LispSyntax.read("""
 (defn f1 [n]
    (if (< n 2)
        1
@@ -92,120 +92,120 @@ end
 
 assign_reader_dispatch(:sx, x -> sx(x.vector...))
 assign_reader_dispatch(:hash, x -> [ x.vector[i] => x.vector[i+1] for i = 1:2:length(x.vector) ])
-@expect LispSyntax.read("#sx[a b c]") == sx(:a, :b, :c)
-@expect LispSyntax.read("#sx [ 1 2 3 ]") == sx(1, 2, 3)
+@test LispSyntax.read("#sx[a b c]") == sx(:a, :b, :c)
+@test LispSyntax.read("#sx [ 1 2 3 ]") == sx(1, 2, 3)
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Code generation
 # ----------------------------------------------------------------------------------------------------------------------
-@expect codegen(desx(LispSyntax.read("(if true a)"))) == :(true && $(esc(:a)))
-@expect codegen(desx(LispSyntax.read("(if true a b)"))) == :(true ? $(esc(:a)) : $(esc(:b)))
+@test codegen(desx(LispSyntax.read("(if true a)"))) == :(true && $(esc(:a)))
+@test codegen(desx(LispSyntax.read("(if true a b)"))) == :(true ? $(esc(:a)) : $(esc(:b)))
 
-@expect codegen(desx(LispSyntax.read("(call)"))) == :($(esc(:call))())
-@expect codegen(desx(LispSyntax.read("(call a)"))) == :($(esc(:call))($(esc(:a))))
-@expect codegen(desx(LispSyntax.read("(call a b)"))) == :($(esc(:call))($(esc(:a)), $(esc(:b))))
-@expect codegen(desx(LispSyntax.read("(call a b c)"))) == :($(esc(:call))($(esc(:a)), $(esc(:b)), $(esc(:c))))
+@test codegen(desx(LispSyntax.read("(call)"))) == :($(esc(:call))())
+@test codegen(desx(LispSyntax.read("(call a)"))) == :($(esc(:call))($(esc(:a))))
+@test codegen(desx(LispSyntax.read("(call a b)"))) == :($(esc(:call))($(esc(:a)), $(esc(:b))))
+@test codegen(desx(LispSyntax.read("(call a b c)"))) == :($(esc(:call))($(esc(:a)), $(esc(:b)), $(esc(:c))))
 
-@expect codegen(desx(LispSyntax.read("(lambda (x) (call x))"))) == Expr(:function, :((x,)), Expr(:block, :($(esc(:call))(x))))
-@expect codegen(desx(LispSyntax.read("(def x 3)"))) == :($(esc(:x)) = 3)
-@expect codegen(desx(LispSyntax.read("(def x (+ 3 1))"))) == :($(esc(:x)) = $(esc(:+))(3, 1))
+@test codegen(desx(LispSyntax.read("(lambda (x) (call x))"))) == Expr(:function, :((x,)), Expr(:block, :($(esc(:call))(x))))
+@test codegen(desx(LispSyntax.read("(def x 3)"))) == :($(esc(:x)) = 3)
+@test codegen(desx(LispSyntax.read("(def x (+ 3 1))"))) == :($(esc(:x)) = $(esc(:+))(3, 1))
 
-@expect codegen(desx(LispSyntax.read("test"))) == :($(esc(:test)))
-@expect codegen(desx(LispSyntax.read("'test"))) == QuoteNode(:test)
-@expect codegen(desx(LispSyntax.read("'(1 2)"))) == :(construct_sexpr(1, 2))
-@expect codegen(desx(LispSyntax.read("'(1 x)"))) == :(construct_sexpr(1, :x))
-@expect codegen(desx(LispSyntax.read("'(1 (1 2))"))) == :(construct_sexpr(1, construct_sexpr(1, 2)))
-@expect codegen(desx(LispSyntax.read("'(1 (test x))"))) == :(construct_sexpr(1, construct_sexpr(:test, :x)))
-@expect codegen(desx(LispSyntax.read("(call 1 '2)"))) == :($(esc(:call))(1, 2))
+@test codegen(desx(LispSyntax.read("test"))) == :($(esc(:test)))
+@test codegen(desx(LispSyntax.read("'test"))) == QuoteNode(:test)
+@test codegen(desx(LispSyntax.read("'(1 2)"))) == :(construct_sexpr(1, 2))
+@test codegen(desx(LispSyntax.read("'(1 x)"))) == :(construct_sexpr(1, :x))
+@test codegen(desx(LispSyntax.read("'(1 (1 2))"))) == :(construct_sexpr(1, construct_sexpr(1, 2)))
+@test codegen(desx(LispSyntax.read("'(1 (test x))"))) == :(construct_sexpr(1, construct_sexpr(:test, :x)))
+@test codegen(desx(LispSyntax.read("(call 1 '2)"))) == :($(esc(:call))(1, 2))
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Scope and variables
 # ----------------------------------------------------------------------------------------------------------------------
 global x = 10
-@expect @lisp("x") == 10
-@expect lisp"x" == 10
+@test @lisp("x") == 10
+@test lisp"x" == 10
 
 lisp"(def w (+ 3 1))"
-@expect w == 4
+@test w == 4
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Quoting and splicing
 # ----------------------------------------------------------------------------------------------------------------------
-@expect @lisp("`~x") == 10
-@expect lisp"`~x" == 10
-@expect lisp"'test" == :test
-@expect lisp"'(1 2)" == Any[1, 2]
-@expect lisp"'(1 x)" == Any[1, :x]
-@expect lisp"'(1 (1 2))" == Any[1, Any[1, 2]]
-@expect lisp"'(1 (test x))" == Any[1, Any[:test, :x]]
-@expect @lisp("`(test ~x)") == Any[ :test, 10 ]
-@expect lisp"`(test ~x)" == Any[ :test, 10 ]
-@expect @lisp("`(~x ~x)") == Any[ 10, 10 ]
+@test @lisp("`~x") == 10
+@test lisp"`~x" == 10
+@test lisp"'test" == :test
+@test lisp"'(1 2)" == Any[1, 2]
+@test lisp"'(1 x)" == Any[1, :x]
+@test lisp"'(1 (1 2))" == Any[1, Any[1, 2]]
+@test lisp"'(1 (test x))" == Any[1, Any[:test, :x]]
+@test @lisp("`(test ~x)") == Any[ :test, 10 ]
+@test lisp"`(test ~x)" == Any[ :test, 10 ]
+@test @lisp("`(~x ~x)") == Any[ 10, 10 ]
 global y = Any[ 1, 2 ]
-@expect @lisp("`(~x ~@y)") == Any[ 10, 1, 2 ]
-@expect @lisp("`(~x ~y)") == Any[ 10, Any[1, 2] ]
+@test @lisp("`(~x ~@y)") == Any[ 10, 1, 2 ]
+@test @lisp("`(~x ~y)") == Any[ 10, Any[1, 2] ]
 
-@expect @lisp("`(10 ~(+ 10 x))") == Any[10, 20]
+@test @lisp("`(10 ~(+ 10 x))") == Any[10, 20]
 
-@expect lisp"(quote (+ 1 2))" == Any[:+, 1, 2]
+@test lisp"(quote (+ 1 2))" == Any[:+, 1, 2]
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Functions
 # ----------------------------------------------------------------------------------------------------------------------
 @lisp("(defn xxx [a b] (+ a b))")
-@expect @lisp("(xxx 1 2)") == 3
+@test @lisp("(xxx 1 2)") == 3
 
 global z = 10
 @lisp("(defn yyy [a] (+ a z))")
-@expect @lisp("(yyy 1)") == 11
-@expect @lisp("(yyy z)") == 20
+@test @lisp("(yyy 1)") == 11
+@test @lisp("(yyy z)") == 20
 
 # recursion
 lisp"(defn fib [a] (if (< a 2) a (+ (fib (- a 1)) (fib (- a 2)))))"
-@expect lisp"(fib 2)" == 1
-@expect lisp"(fib 4)" == 3
-@expect lisp"(fib 30)" == 832040
-@expect lisp"(fib 40)" == 102334155
+@test lisp"(fib 2)" == 1
+@test lisp"(fib 4)" == 3
+@test lisp"(fib 30)" == 832040
+@test lisp"(fib 40)" == 102334155
 
 # Note this version is very slow due to the anonymous function
 lisp"(def fib2 (lambda [a] (if (< a 2) a (+ (fib2 (- a 1)) (fib2 (- a 2))))))"
-@expect lisp"(fib2 2)" == 1
-@expect lisp"(fib2 4)" == 3
-@expect lisp"(fib2 30)" == 832040
+@test lisp"(fib2 2)" == 1
+@test lisp"(fib2 4)" == 3
+@test lisp"(fib2 30)" == 832040
 
 lisp"(defn dostuff [a] (@incr a) (@incr a) (@incr a))"
-@expect lisp"(dostuff 3)" == 6
-@expect lisp"(dostuff 6)" == 9
+@test lisp"(dostuff 3)" == 6
+@test lisp"(dostuff 6)" == 9
 
 lisp"(def dostuff2 (lambda [a] (@incr a) (@incr a) (@incr a)))"
-@expect lisp"(dostuff2 3)" == 6
-@expect lisp"(dostuff2 6)" == 9
+@test lisp"(dostuff2 3)" == 6
+@test lisp"(dostuff2 6)" == 9
 
 lisp"(def dostuff3 (fn [a] (@incr a) (@incr a) (@incr a)))"
-@expect lisp"(dostuff3 3)" == 6
-@expect lisp"(dostuff3 6)" == 9
-@expect lisp"((lambda [x] (+ x 1)) 5)" == 6
-@expect lisp"#{1 2 z}" == Set([1, 2, 10])
-@expect lisp"{1 2 2 z}" == Dict(1 => 2, 2 => 10)
-@expect lisp"#sx[+ 1 2]" == 3
-@expect lisp"#hash['+ 1 '- z]" == Dict(:+ => 1, :- => 10)
+@test lisp"(dostuff3 3)" == 6
+@test lisp"(dostuff3 6)" == 9
+@test lisp"((lambda [x] (+ x 1)) 5)" == 6
+@test lisp"#{1 2 z}" == Set([1, 2, 10])
+@test lisp"{1 2 2 z}" == Dict(1 => 2, 2 => 10)
+@test lisp"#sx[+ 1 2]" == 3
+@test lisp"#hash['+ 1 '- z]" == Dict(:+ => 1, :- => 10)
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Macros
 # ----------------------------------------------------------------------------------------------------------------------
 lisp"(defn fact [a] (if (< a 1) 1 (* a (fact (- a 1)))))"
 lisp"(defmacro fapply [f a] `(~f ~a))"
-@expect @fapply(fib2, 2) == 1
-@expect @fapply(fact, 3 + 1) == 24
-@expect lisp"(@fapply fib2 2)" == 1
-@expect lisp"(@fapply fact (+ 3 1))" == 24
+@test @fapply(fib2, 2) == 1
+@test @fapply(fact, 3 + 1) == 24
+@test lisp"(@fapply fib2 2)" == 1
+@test lisp"(@fapply fact (+ 3 1))" == 24
 
 fcount = 0
 lisp"(defmacro fapply_trace [f a] (global fcount) (@incr fcount) `(~f ~a))"
-@expect @fapply_trace(fib2, 2) == 1
-@expect fcount == 1
-@expect @fapply_trace(fact, 3 + 1) == 24
-@expect fcount == 2
+@test @fapply_trace(fib2, 2) == 1
+@test fcount == 1
+@test @fapply_trace(fact, 3 + 1) == 24
+@test fcount == 2
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Loops
@@ -214,40 +214,40 @@ number = 0
 output = 0
 
 lisp"(while (< number 2) (@incr number) (@incr output))"
-@expect number == 2
-@expect output == 2
+@test number == 2
+@test output == 2
 r = output
 lisp"(for [i (range 1 10)] (@incr r))"
-@expect r == 12
+@test r == 12
 
 r = 0
 lisp"(for [i (range 1 10) j (range 1 10)] (@incr r))"
-@expect r == 100
+@test r == 100
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Let and do
 # ----------------------------------------------------------------------------------------------------------------------
-@expect lisp"(let [x 10] x)" == 10
-@expect lisp"(let [x 10 y 20] (+ x y))" == 30
-@expect lisp"(let [x 10 y 20 z 20] (+ x y z))" == 50
-@expect lisp"(let [x 10 y 20 z 20] (+ x y z number))" == 52
-@expect lisp"(let [x 10 y 20 z 20 number 10] (+ x y z number))" == 60
-@expect lisp"(let [x 10 y 20 z 20] (- (+ x y z number) output))" == 50
+@test lisp"(let [x 10] x)" == 10
+@test lisp"(let [x 10 y 20] (+ x y))" == 30
+@test lisp"(let [x 10 y 20 z 20] (+ x y z))" == 50
+@test lisp"(let [x 10 y 20 z 20] (+ x y z number))" == 52
+@test lisp"(let [x 10 y 20 z 20 number 10] (+ x y z number))" == 60
+@test lisp"(let [x 10 y 20 z 20] (- (+ x y z number) output))" == 50
 
 lisp"(do (@incr r) (@incr number))"
-@expect number == 3
-@expect r == 101
+@test number == 3
+@test r == 101
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Import
 # ----------------------------------------------------------------------------------------------------------------------
 lisp"(import ParserCombinator)"
-@expect lisp"(@E_str \"S\")" == E"S"
+@test lisp"(@E_str \"S\")" == E"S"
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Bug reports
 # ----------------------------------------------------------------------------------------------------------------------
-@expect lisp"""(def game_map (Dict
+@test lisp"""(def game_map (Dict
           (=> 'living_room
               '((you are in the living room
                  of a wizards house - there is a wizard


### PR DESCRIPTION
Various tweaks:

* REQUIRE -> Project.toml
* Use stdlib `Test` for testing. Most of the churn in the test cases is restricted to the first commit - view the commits separately to make this easier to review.
* Fix various functions which are deprecated, including map over Set and Dict which no longer works.

The bigger fix here is to update codegen for julia 1.0:

* Completely redo and simplify how macro escaping works for `@lisp_str` and codegen. The entire expression is now escaped, and we defer scoping decisions (mainly in let) to the julia compiler.  For the few cases where functions from LispSyntax itself need to be called, they are now unescaped by splicing into the generated AST as function references rather than symbols.
* Fix various Exprs where the form has changed between julia 0.4 or so and julia 1.0 (let, using; maybe a couple more)

Fixes #19 by obsoleting it.

@JeffBezanson happy Friday :-)