### PR TITLE
More convenient REPL support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,11 @@
 name = "LispSyntax"
 uuid = "51c06dcf-91d3-5c9e-a52e-02df4e7cbcf5"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 ParserCombinator = "fae87a5f-d1ad-5cf0-8f61-c941e1580b46"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
 
 [compat]
 ParserCombinator = "≥ 2.0.0"

--- a/README.md
+++ b/README.md
@@ -79,64 +79,41 @@ Notable Differences
 
 REPL Mode
 ---------
-In order to avoid having to type out `lisp"( ... )"` for each top level expression,
-one can use [ReplMaker.jl](https://github.com/MasonProtter/ReplMaker.jl) to make a
-REPL mode for LispSyntax.jl
-```julia
-julia> using LispSyntax, ReplMaker
+LispSyntax.jl provides a convenience REPL, alleviating one from having to
+type `lisp"( ... )"` for each top level expression. In order to use REPL
+mode, simply initialize it:
 
-julia> initrepl(LispSyntax.lisp_eval_helper,
-                prompt_text="λ> ",
-                prompt_color=:red,
-                start_key=")",
-                mode_name="Lisp Mode")
+```julia
+julia> using LispSyntax
+julia> LispSyntax.init_repl()
 REPL mode Lisp Mode initialized. Press ) to enter and backspace to exit.
 ```
-As instructed, if we now press `)` at an empty `julia>` prompt, we enter `Lisp Mode`.
-```julia
-λ> (defn fib [a] (if (< a 2) a (+ (fib (- a 1)) (fib (- a 2)))))
-fib (generic function with 1 method)
+At this point, type `)`, and you're ready to Lisp:
 
-λ> (fib 10)
+```clj
+jλ> (* 2 (reduce + (: 1 6)))
+42
+jλ> (defn fib [a] 
+      (if (< a 2) 
+        a 
+        (+ (fib (- a 1)) (fib (- a 2)))))
+fib (generic function with 1 method)
+jλ> (fib 10)
 55
 ```
-to go back to vanilla julia, simply press the backspace button or `Ctrl-C`
+
+To return to the Julia prompt, simply type the backspace type or 
+`Ctrl-C`. Once there, you'll still have access to the fuctions you 
+defined:
 ```julia
 julia> fib
 fib (generic function with 1 method)
-
+julia> fib(10)
+55
 ```
 
-If one want to support multi-line s-expressions then you must define 
-a `valid_input_checker` for the REPL mode as follows:
-```julia
-julia> using REPL: REPL, LineEdit; using LispSyntax: ParserCombinator
+You may also create a [customized REPL](docs/repl-mode.md).
 
-julia> function valid_sexpr(s)
-         try
-           LispSyntax.read(String(take!(copy(LineEdit.buffer(s)))))
-           true
-         catch err
-           isa(err, ParserCombinator.ParserException) || rethrow(err)
-           false
-         end
-       end
-valid_sexpr (generic function with 1 method)
-
-julia> initrepl(LispSyntax.lisp_eval_helper,
-                valid_input_checker=valid_sexpr,
-                prompt_text="λ> ",
-                prompt_color=:red,
-                start_key=")",
-                mode_name="Lisp Mode")
-REPL mode Lisp Mode initialized. Press ) to enter and backspace to exit.
-
-λ> (defn fib [a] 
-    (if (< a 2) 
-      a 
-      (+ (fib (- a 1)) (fib (- a 2)))))
-fib (generic function with 1 method)
-```
 
 TODO
 ----

--- a/docs/repl-mode.md
+++ b/docs/repl-mode.md
@@ -1,0 +1,60 @@
+# Custom REPL Mode
+
+LispSyntax.jl provides a default REPL mode, but if you'd like to
+customize your own, you may do so by using 
+[ReplMaker.jl](https://github.com/MasonProtter/ReplMaker.jl)
+directly:
+```julia
+julia> using LispSyntax, ReplMaker
+
+julia> ReplMaker.initrepl(LispSyntax.lisp_eval_helper,
+                prompt_text="λ> ",
+                prompt_color=:red,
+                start_key=")",
+                mode_name="Lisp Mode")
+REPL mode Lisp Mode initialized. Press ) to enter and backspace to exit.
+```
+At this point, type `)`, and you're ready to Lisp:
+
+```clj
+λ> (* 2 (reduce + (: 1 6)))
+42
+λ> (defn fib [a] (if (< a 2) a (+ (fib (- a 1)) (fib (- a 2)))))
+fib (generic function with 1 method)
+λ> (fib 10)
+55
+```
+
+If you want to support multi-line S-expressions then you must define 
+a `valid_input_checker` for the REPL mode as follows:
+```julia
+julia> using REPL: REPL, LineEdit; using LispSyntax: ParserCombinator
+
+julia> function lisp_reader(s)
+         try
+           LispSyntax.read(String(take!(copy(LineEdit.buffer(s)))))
+           true
+         catch err
+           isa(err, ParserCombinator.ParserException) || rethrow(err)
+           false
+         end
+       end
+valid_sexpr (generic function with 1 method)
+
+julia> initrepl(LispSyntax.lisp_eval_helper,
+                valid_input_checker=lisp_reader,
+                prompt_text="λ> ",
+                prompt_color=:red,
+                start_key=")",
+                mode_name="Lisp Mode")
+REPL mode Lisp Mode initialized. Press ) to enter and backspace to exit.
+```
+```clj
+λ> (defn fib [a] 
+    (if (< a 2) 
+      a 
+      (+ (fib (- a 1)) (fib (- a 2)))))
+fib (generic function with 1 method)
+```
+
+Note that this is provided by default with `LispSyntax.init_repl`.

--- a/src/LispSyntax.jl
+++ b/src/LispSyntax.jl
@@ -181,4 +181,6 @@ function include_lisp(mod::Module, io::IO)
     res
 end
 
+include("repl.jl")
+
 end # module

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -12,12 +12,13 @@ function lisp_reader(s)
     end
 end
 
-function init_repl()
-    ReplMaker.initrepl(lisp_eval_helper,
-                  repl = Base.active_repl,
-                  valid_input_checker = lisp_reader,
-                  prompt_text = "jλ> ",
-                  prompt_color = :yellow,
-                  start_key = ")",
-                  mode_name = "Lisp Mode")
+function init_repl(; prompt_text="jλ> ", prompt_color = :red, start_key = ")", sticky=true)
+	    ReplMaker.initrepl(lisp_eval_helper,
+	                  repl = Base.active_repl,
+	                  valid_input_checker = lisp_reader,
+	                  prompt_text = prompt_text,
+	                  prompt_color = prompt_color,
+	                  start_key = start_key,
+                          sticky_mode=sticky,
+	                  mode_name = "Lisp Mode")
 end

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -1,0 +1,23 @@
+using ParserCombinator
+using REPL: REPL, LineEdit
+using ReplMaker
+
+function lisp_reader(s)
+    try
+        read(String(take!(copy(LineEdit.buffer(s)))))
+        true
+    catch err
+        isa(err, ParserCombinator.ParserException) || rethrow(err)
+        false
+    end
+end
+
+function init_repl()
+    ReplMaker.initrepl(lisp_eval_helper,
+                  repl = Base.active_repl,
+                  valid_input_checker = lisp_reader,
+                  prompt_text = "jλ> ",
+                  prompt_color = :yellow,
+                  start_key = ")",
+                  mode_name = "Lisp Mode")
+end


### PR DESCRIPTION
I've tweaked the REPL support to include some sane defaults. Added custom REPL tweaking to its own Markdown file in the `docs` dir.